### PR TITLE
Add windows host build support in CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,13 @@ set(CPU_HEADERS
         cpu.h)
 add_library(retro_cpu_core ${CPU_SOURCES} ${CPU_HEADERS})
 
-set(HOST_LINUX_SOURCES host/host_linux.cc)
-add_library(retro_host_linux ${HOST_LINUX_SOURCES})
-target_include_directories(retro_host_linux PUBLIC ./)
+if(WIN32)
+set(HOST_SOURCES host/host_win32.cc)
+else()
+set(HOST_SOURCES host/host_linux.cc)
+endif()
+add_library(retro_host ${HOST_SOURCES})
+target_include_directories(retro_host PUBLIC ./)
 
 set(CPU_65816_SOURCES
     cpu/65816/cpu_65c816.cc)
@@ -20,5 +24,5 @@ set(CPU_65816_HEADERS
     cpu/65816/cpu_65c816.h)
 
 add_library(retro_cpu_65816 ${CPU_65816_SOURCES} ${CPU_65816_HEADERS})
-add_dependencies(retro_cpu_65816 retro_host_linux retro_cpu_core)
+add_dependencies(retro_cpu_65816 retro_host retro_cpu_core)
 target_include_directories(retro_cpu_65816 PUBLIC ./)


### PR DESCRIPTION
Build a target 'retro_host' that is either the win32 or linux version depending on platform.